### PR TITLE
Refactor application and sub-app factory tests; remove unused Prettie…

### DIFF
--- a/src/lib/application/application.factory.test.ts
+++ b/src/lib/application/application.factory.test.ts
@@ -1,7 +1,4 @@
-import {
-  SchematicTestRunner,
-  UnitTestTree,
-} from '@angular-devkit/schematics/testing'
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing'
 import * as path from 'path'
 import {ApplicationOptions} from './application.schema'
 
@@ -13,7 +10,6 @@ const expected_files = [
   'tsconfig.json',
   '.dockerignore',
   '.gitignore',
-  '.prettierrc',
   'Dockerfile',
   'docker-compose.yaml',
   'src/app.module.ts',
@@ -24,23 +20,22 @@ const expected_files = [
 ]
 
 const expected_jsfiles = [
-  ".babelrc",
+  '.babelrc',
   'README.md',
-  "index.js",
-  "jsconfig.json",
-  "nest-cli.json",
-  "nodemon.json",
-  "package.json",
+  'index.js',
+  'jsconfig.json',
+  'nest-cli.json',
+  'nodemon.json',
+  'package.json',
   '.dockerignore',
-  ".gitignore",
-  ".prettierrc",
+  '.gitignore',
   'Dockerfile',
   'docker-compose.yaml',
-  "src/app.module.js",
-  "src/exception-filter.js",
-  "src/main.js",
-  "test/app.e2e-spec.js",
-  "test/jest-e2e.json",
+  'src/app.module.js',
+  'src/exception-filter.js',
+  'src/main.js',
+  'test/app.e2e-spec.js',
+  'test/jest-e2e.json',
 ]
 
 describe('Application Factory', () => {

--- a/src/lib/application/files/js/package.json
+++ b/src/lib/application/files/js/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "format": "prettier --write \"**/*.js\"",
     "start": "babel-node index.js",
     "start:dev": "nodemon",
     "test": "jest",
@@ -22,7 +21,6 @@
     "class-validator": "*",
     "reflect-metadata": "*",
     "rxjs": "*"
-
   },
   "devDependencies": {
     "@nestjs/testing": "*",
@@ -36,7 +34,6 @@
     "@babel/runtime": "*",
     "jest": "*",
     "nodemon": "*",
-    "prettier": "*",
     "supertest": "*"
   },
   "jest": {

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -7,7 +7,6 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
@@ -37,7 +36,6 @@
     "@types/node": "*",
     "@types/supertest": "*",
     "jest": "*",
-    "prettier": "*",
     "source-map-support": "*",
     "supertest": "*",
     "ts-jest": "*",

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -1,26 +1,9 @@
-import { join, normalize, Path, strings } from '@angular-devkit/core'
-import {
-  apply,
-  branchAndMerge,
-  chain,
-  mergeWith,
-  move,
-  Rule,
-  SchematicsException,
-  Source,
-  template,
-  Tree,
-  url,
-} from '@angular-devkit/schematics'
-import { parse } from 'jsonc-parser'
-import { normalizeToKebabOrSnakeCase } from '../../utils/formatting'
-import {
-  DEFAULT_LANGUAGE,
-  DEFAULT_LIB_PATH,
-  DEFAULT_PATH_NAME,
-  PROJECT_TYPE,
-} from '../defaults'
-import { LibraryOptions } from './library.schema'
+import {join, normalize, Path, strings} from '@angular-devkit/core'
+import {apply, branchAndMerge, chain, mergeWith, move, Rule, SchematicsException, Source, template, Tree, url} from '@angular-devkit/schematics'
+import {parse} from 'jsonc-parser'
+import {normalizeToKebabOrSnakeCase} from '../../utils/formatting'
+import {DEFAULT_LANGUAGE, DEFAULT_LIB_PATH, DEFAULT_PATH_NAME, PROJECT_TYPE} from '../defaults'
+import {LibraryOptions} from './library.schema'
 
 type UpdateJsonFn<T> = (obj: T) => T | void
 interface TsConfigPartialType {
@@ -45,18 +28,16 @@ export function main(options: LibraryOptions): Rule {
 
 function transform(options: LibraryOptions): LibraryOptions {
   const target: LibraryOptions = Object.assign({}, options)
-  const defaultSourceRoot =
-    options.rootDir !== undefined ? options.rootDir : DEFAULT_LIB_PATH
+  const defaultSourceRoot = options.rootDir !== undefined ? options.rootDir : DEFAULT_LIB_PATH
 
   if (!target.name) {
     throw new SchematicsException('Option (name) is required.')
   }
   target.language = !!target.language ? target.language : DEFAULT_LANGUAGE
   target.name = normalizeToKebabOrSnakeCase(target.name)
-  target.path =
-    target.path !== undefined
-      ? join(normalize(defaultSourceRoot), target.path)
-      : normalize(defaultSourceRoot)
+  target.path = target.path !== undefined
+    ? join(normalize(defaultSourceRoot), target.path)
+    : normalize(defaultSourceRoot)
 
   target.prefix = target.prefix || '@app'
   return target
@@ -76,7 +57,6 @@ function updatePackageJson(options: LibraryOptions) {
       host,
       'package.json',
       (packageJson: Record<string, any>) => {
-        updateNpmScripts(packageJson.scripts, options)
         updateJestConfig(packageJson.jest, options, packageKey, distRoot)
       },
     )
@@ -96,8 +76,7 @@ function updateJestConfig(
     jestOptions.rootDir = '.'
     jestOptions.coverageDirectory = './coverage'
   }
-  const defaultSourceRoot =
-    options.rootDir !== undefined ? options.rootDir : DEFAULT_LIB_PATH
+  const defaultSourceRoot = options.rootDir !== undefined ? options.rootDir : DEFAULT_LIB_PATH
 
   const jestSourceRoot = `<rootDir>/${defaultSourceRoot}/`
   if (!jestOptions.roots) {
@@ -112,30 +91,6 @@ function updateJestConfig(
   const packageKeyRegex = '^' + packageKey + '(|/.*)$'
   const packageRoot = join('<rootDir>' as Path, distRoot)
   jestOptions.moduleNameMapper[packageKeyRegex] = join(packageRoot, '$1')
-}
-
-function updateNpmScripts(
-  scripts: Record<string, any>,
-  options: LibraryOptions,
-) {
-  if (!scripts) {
-    return
-  }
-  const defaultFormatScriptName = 'format'
-  if (!scripts[defaultFormatScriptName]) {
-    return
-  }
-
-  if (
-    scripts[defaultFormatScriptName] &&
-    scripts[defaultFormatScriptName].indexOf(DEFAULT_PATH_NAME) >= 0
-  ) {
-    const defaultSourceRoot =
-      options.rootDir !== undefined ? options.rootDir : DEFAULT_LIB_PATH
-    scripts[
-      defaultFormatScriptName
-    ] = `prettier --write "src/**/*.ts" "test/**/*.ts" "${defaultSourceRoot}/**/*.ts"`
-  }
 }
 
 function updateJestEndToEnd(options: LibraryOptions) {

--- a/src/lib/sub-app/files/js/package.json
+++ b/src/lib/sub-app/files/js/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "format": "prettier --write \"**/*.js\"",
     "start": "babel-node index.js",
     "start:dev": "nodemon",
     "test": "jest",
@@ -22,7 +21,6 @@
     "class-validator": "*",
     "reflect-metadata": "*",
     "rxjs": "*"
-
   },
   "devDependencies": {
     "@nestjs/testing": "*",
@@ -36,7 +34,6 @@
     "@babel/runtime": "*",
     "jest": "*",
     "nodemon": "*",
-    "prettier": "*",
     "supertest": "*"
   },
   "jest": {

--- a/src/lib/sub-app/files/ts/package.json
+++ b/src/lib/sub-app/files/ts/package.json
@@ -11,7 +11,6 @@
     "clean": "rimraf dist",
     "clean:all": "rimraf node_modules temp",
     "preclean:all": "npm run clean",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nodemon -V --delay 3s --legacy-watch -w src $(realpath ../../libs/*/dist | grep -v 'client-api\\|components\\|style' | sed 's/^/-w /') -e '*' -x 'while :; do nest start; sleep 5; kill $(lsof -ti:$(sed -n \"s/const port = //p\" src/main.ts)); done'",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/src/lib/sub-app/sub-app.factory.test.ts
+++ b/src/lib/sub-app/sub-app.factory.test.ts
@@ -1,7 +1,4 @@
-import {
-  SchematicTestRunner,
-  UnitTestTree,
-} from '@angular-devkit/schematics/testing'
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing'
 import * as path from 'path'
 import {SubAppOptions} from './sub-app.schema'
 
@@ -21,21 +18,21 @@ describe('SubApp Factory', () => {
     expect(files.sort()).toEqual([
       '/nest-cli.json',
       '/backends/scrypt-swiss-nest-templates/tsconfig.json',
-      "/backends/project/.dockerignore",
-      "/backends/project/.gitignore",
-      "/backends/project/.prettierrc",
-      "/backends/project/Dockerfile",
-      "/backends/project/README.md",
-      "/backends/project/docker-compose.yaml",
-      "/backends/project/nest-cli.json",
-      "/backends/project/package.json",
-      "/backends/project/src/app.module.ts",
-      "/backends/project/src/exception-filter.ts",
-      "/backends/project/src/main.ts",
-      "/backends/project/test/app.e2e-spec.ts",
-      "/backends/project/test/jest-e2e.json",
-      "/backends/project/tsconfig.build.json",
-      "/backends/project/tsconfig.json"].sort())
+      '/backends/project/.dockerignore',
+      '/backends/project/.gitignore',
+      '/backends/project/Dockerfile',
+      '/backends/project/README.md',
+      '/backends/project/docker-compose.yaml',
+      '/backends/project/nest-cli.json',
+      '/backends/project/package.json',
+      '/backends/project/src/app.module.ts',
+      '/backends/project/src/exception-filter.ts',
+      '/backends/project/src/main.ts',
+      '/backends/project/test/app.e2e-spec.ts',
+      '/backends/project/test/jest-e2e.json',
+      '/backends/project/tsconfig.build.json',
+      '/backends/project/tsconfig.json',
+    ].sort())
   })
   it('should manage name to normalize', async () => {
     const options: SubAppOptions = {
@@ -46,23 +43,22 @@ describe('SubApp Factory', () => {
       .toPromise()
     const files: string[] = tree.files
     expect(files.sort()).toEqual([
-      "/backends/awesome-project/.dockerignore",
-      "/backends/awesome-project/.gitignore",
-      "/backends/awesome-project/.prettierrc",
-      "/backends/awesome-project/Dockerfile",
-      "/backends/awesome-project/README.md",
-      "/backends/awesome-project/docker-compose.yaml",
-      "/backends/awesome-project/nest-cli.json",
-      "/backends/awesome-project/package.json",
-      "/backends/awesome-project/src/app.module.ts",
-      "/backends/awesome-project/src/exception-filter.ts",
-      "/backends/awesome-project/src/main.ts",
-      "/backends/awesome-project/test/app.e2e-spec.ts",
-      "/backends/awesome-project/test/jest-e2e.json",
-      "/backends/awesome-project/tsconfig.build.json",
-      "/backends/awesome-project/tsconfig.json",
-      "/backends/scrypt-swiss-nest-templates/tsconfig.json",
-      "/nest-cli.json",
+      '/backends/awesome-project/.dockerignore',
+      '/backends/awesome-project/.gitignore',
+      '/backends/awesome-project/Dockerfile',
+      '/backends/awesome-project/README.md',
+      '/backends/awesome-project/docker-compose.yaml',
+      '/backends/awesome-project/nest-cli.json',
+      '/backends/awesome-project/package.json',
+      '/backends/awesome-project/src/app.module.ts',
+      '/backends/awesome-project/src/exception-filter.ts',
+      '/backends/awesome-project/src/main.ts',
+      '/backends/awesome-project/test/app.e2e-spec.ts',
+      '/backends/awesome-project/test/jest-e2e.json',
+      '/backends/awesome-project/tsconfig.build.json',
+      '/backends/awesome-project/tsconfig.json',
+      '/backends/scrypt-swiss-nest-templates/tsconfig.json',
+      '/nest-cli.json',
     ].sort())
   })
   it("should keep underscores in sub-app's path and file name", async () => {
@@ -74,23 +70,23 @@ describe('SubApp Factory', () => {
       .toPromise()
     const files: string[] = tree.files
     expect(files.sort()).toEqual([
-      "/backends/_project/.dockerignore",
-      "/backends/_project/.gitignore",
-      "/backends/_project/.prettierrc",
-      "/backends/_project/Dockerfile",
-      "/backends/_project/README.md",
-      "/backends/_project/docker-compose.yaml",
-      "/backends/_project/nest-cli.json",
-      "/backends/_project/package.json",
-      "/backends/_project/src/app.module.ts",
-      "/backends/_project/src/exception-filter.ts",
-      "/backends/_project/src/main.ts",
-      "/backends/_project/test/app.e2e-spec.ts",
-      "/backends/_project/test/jest-e2e.json",
-      "/backends/_project/tsconfig.build.json",
-      "/backends/_project/tsconfig.json",
-      "/backends/scrypt-swiss-nest-templates/tsconfig.json",
-      "/nest-cli.json",].sort())
+      '/backends/_project/.dockerignore',
+      '/backends/_project/.gitignore',
+      '/backends/_project/Dockerfile',
+      '/backends/_project/README.md',
+      '/backends/_project/docker-compose.yaml',
+      '/backends/_project/nest-cli.json',
+      '/backends/_project/package.json',
+      '/backends/_project/src/app.module.ts',
+      '/backends/_project/src/exception-filter.ts',
+      '/backends/_project/src/main.ts',
+      '/backends/_project/test/app.e2e-spec.ts',
+      '/backends/_project/test/jest-e2e.json',
+      '/backends/_project/tsconfig.build.json',
+      '/backends/_project/tsconfig.json',
+      '/backends/scrypt-swiss-nest-templates/tsconfig.json',
+      '/nest-cli.json',
+    ].sort())
   })
   it('should manage javascript files', async () => {
     const options: SubAppOptions = {
@@ -102,27 +98,26 @@ describe('SubApp Factory', () => {
       .toPromise()
     const files: string[] = tree.files
     expect(files.sort()).toEqual([
-      "/backends/project/.babelrc",
-      "/backends/project/.dockerignore",
-      "/backends/project/.gitignore",
-      "/backends/project/.prettierrc",
-      "/backends/project/Dockerfile",
-      "/backends/project/README.md",
-      "/backends/project/docker-compose.yaml",
-      "/backends/project/index.js",
-      "/backends/project/jsconfig.json",
-      "/backends/project/nest-cli.json",
-      "/backends/project/nodemon.json",
-      "/backends/project/package.json",
-      "/backends/project/src/app.module.js",
-      "/backends/project/src/exception-filter.js",
-      "/backends/project/src/main.js",
-      "/backends/project/test/app.e2e-spec.js",
-      "/backends/project/test/jest-e2e.json",
-      "/backends/scrypt-swiss-nest-templates/.babelrc",
-      "/backends/scrypt-swiss-nest-templates/index.js",
-      "/backends/scrypt-swiss-nest-templates/jsconfig.json",
-      "/nest-cli.json",
+      '/backends/project/.babelrc',
+      '/backends/project/.dockerignore',
+      '/backends/project/.gitignore',
+      '/backends/project/Dockerfile',
+      '/backends/project/README.md',
+      '/backends/project/docker-compose.yaml',
+      '/backends/project/index.js',
+      '/backends/project/jsconfig.json',
+      '/backends/project/nest-cli.json',
+      '/backends/project/nodemon.json',
+      '/backends/project/package.json',
+      '/backends/project/src/app.module.js',
+      '/backends/project/src/exception-filter.js',
+      '/backends/project/src/main.js',
+      '/backends/project/test/app.e2e-spec.js',
+      '/backends/project/test/jest-e2e.json',
+      '/backends/scrypt-swiss-nest-templates/.babelrc',
+      '/backends/scrypt-swiss-nest-templates/index.js',
+      '/backends/scrypt-swiss-nest-templates/jsconfig.json',
+      '/nest-cli.json',
     ].sort())
   })
   it('should generate spec files with custom suffix', async () => {
@@ -135,23 +130,22 @@ describe('SubApp Factory', () => {
       .toPromise()
     const files: string[] = tree.files
     expect(files.sort()).toEqual([
-      "/backends/project/.dockerignore",
-      "/backends/project/.gitignore",
-      "/backends/project/.prettierrc",
-      "/backends/project/Dockerfile",
-      "/backends/project/README.md",
-      "/backends/project/docker-compose.yaml",
-      "/backends/project/nest-cli.json",
-      "/backends/project/package.json",
-      "/backends/project/src/app.module.ts",
-      "/backends/project/src/exception-filter.ts",
-      "/backends/project/src/main.ts",
-      "/backends/project/test/app.e2e-spec.ts",
-      "/backends/project/test/jest-e2e.json",
-      "/backends/project/tsconfig.build.json",
-      "/backends/project/tsconfig.json",
-      "/backends/scrypt-swiss-nest-templates/tsconfig.json",
-      "/nest-cli.json",
+      '/backends/project/.dockerignore',
+      '/backends/project/.gitignore',
+      '/backends/project/Dockerfile',
+      '/backends/project/README.md',
+      '/backends/project/docker-compose.yaml',
+      '/backends/project/nest-cli.json',
+      '/backends/project/package.json',
+      '/backends/project/src/app.module.ts',
+      '/backends/project/src/exception-filter.ts',
+      '/backends/project/src/main.ts',
+      '/backends/project/test/app.e2e-spec.ts',
+      '/backends/project/test/jest-e2e.json',
+      '/backends/project/tsconfig.build.json',
+      '/backends/project/tsconfig.json',
+      '/backends/scrypt-swiss-nest-templates/tsconfig.json',
+      '/nest-cli.json',
     ].sort())
   })
 })

--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -53,20 +53,17 @@ function getAppNameFromPackageJson(): string {
 }
 
 function transform(options: SubAppOptions): SubAppOptions {
-
   const target: SubAppOptions = Object.assign({}, options)
-  const defaultSourceRoot =
-    options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
+  const defaultSourceRoot = options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
 
   if (!target.name) {
     target.name = DEFAULT_APP_NAME
   }
   target.language = !!target.language ? target.language : DEFAULT_LANGUAGE
   target.name = normalizeToKebabOrSnakeCase(target.name)
-  target.path =
-    target.path !== undefined
-      ? join(normalize(defaultSourceRoot), target.path)
-      : normalize(defaultSourceRoot)
+  target.path = target.path !== undefined
+    ? join(normalize(defaultSourceRoot), target.path)
+    : normalize(defaultSourceRoot)
   target.packageManager ??= 'npm'
   target.author ??= ''
   target.description ??= ''
@@ -155,15 +152,15 @@ function updateNpmScripts(
   const defaultStartScriptName = 'start:prod'
   const defaultTestScriptName = 'test:e2e'
   if (
-    !scripts[defaultTestScriptName] &&
-    !scripts[defaultFormatScriptName] &&
-    !scripts[defaultStartScriptName]
+    !scripts[defaultTestScriptName]
+    && !scripts[defaultFormatScriptName]
+    && !scripts[defaultStartScriptName]
   ) {
     return
   }
   if (
-    scripts[defaultTestScriptName] &&
-    scripts[defaultTestScriptName].indexOf(options.path as string) < 0
+    scripts[defaultTestScriptName]
+    && scripts[defaultTestScriptName].indexOf(options.path as string) < 0
   ) {
     const defaultTestDir = 'test'
     const newTestDir = join(
@@ -176,21 +173,10 @@ function updateNpmScripts(
     ).replace(defaultTestDir, newTestDir)
   }
   if (
-    scripts[defaultFormatScriptName] &&
-    scripts[defaultFormatScriptName].indexOf(DEFAULT_PATH_NAME) >= 0
+    scripts[defaultStartScriptName]
+    && scripts[defaultStartScriptName].indexOf('dist/main') >= 0
   ) {
-    const defaultSourceRoot =
-      options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
-    scripts[
-      defaultFormatScriptName
-    ] = `prettier --write "${defaultSourceRoot}/**/*.ts" "${DEFAULT_LIB_PATH}/**/*.ts"`
-  }
-  if (
-    scripts[defaultStartScriptName] &&
-    scripts[defaultStartScriptName].indexOf('dist/main') >= 0
-  ) {
-    const defaultSourceRoot =
-      options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
+    const defaultSourceRoot = options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
     scripts[
       defaultStartScriptName
     ] = `node dist/${defaultSourceRoot}/${defaultAppName}/main`
@@ -208,8 +194,7 @@ function updateJestOptions(
     jestOptions.rootDir = '.'
     jestOptions.coverageDirectory = './coverage'
   }
-  const defaultSourceRoot =
-    options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
+  const defaultSourceRoot = options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH
   const jestSourceRoot = `<rootDir>/${defaultSourceRoot}/`
   if (!jestOptions.roots) {
     jestOptions.roots = [jestSourceRoot]
@@ -217,10 +202,9 @@ function updateJestOptions(
     jestOptions.roots.push(jestSourceRoot)
 
     const originalSourceRoot = `<rootDir>/src/`
-    const originalSourceRootIndex =
-      jestOptions.roots.indexOf(originalSourceRoot)
+    const originalSourceRootIndex = jestOptions.roots.indexOf(originalSourceRoot)
     if (originalSourceRootIndex >= 0) {
-      (jestOptions.roots as string[]).splice(originalSourceRootIndex, 1)
+      ;(jestOptions.roots as string[]).splice(originalSourceRootIndex, 1)
     }
   }
 }
@@ -364,6 +348,6 @@ function generate(options: SubAppOptions): Rule {
         ...options,
       }),
       move(path),
-    ]))
+    ])),
   ])
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Prettier-related scripts and dependencies from project configuration files.
  * Cleaned up references to `.prettierrc` in test files and expected file lists.

* **Style**
  * Improved code formatting and consistency in several files, including import statements and string literal usage.
  * Applied stylistic updates to test files, such as consolidating import statements and normalizing quotes.

* **Refactor**
  * Removed logic related to updating or managing the "format" npm script in library and sub-app generation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->