### PR TITLE
use absolute path in dockerfile workdir

### DIFF
--- a/src/lib/sub-app/files/common/Dockerfile
+++ b/src/lib/sub-app/files/common/Dockerfile
@@ -7,7 +7,7 @@ RUN npx nx run <%= name %>:build
 ENV NODE_ENV 'production'
 RUN find -name node_modules -prune -exec rm -rf {} \;
 RUN npm install
-WORKDIR <%= path %>/<%= name %>
+WORKDIR /app/<%= path %>/<%= name %>
 RUN nexe --build --python=$(which python3) -r "temp" -r "dist/migrations" -o app dist/src/main.js
 
 FROM mwaeckerlin/nexe as production


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the working directory path in the Dockerfile to use an absolute path for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->