### PR TITLE
feat(build): npm ci --ignore-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also Generates:
 
     nest new -c @scrypt-swiss/nest-templates -p npm -l ts test
     cd test
-    npm install
+    npm ci --ignore-scripts
     npm run start:debug
 
 Or:
@@ -61,7 +61,7 @@ Create a database, run initial migration (if you don't use SQLitem then you need
     cd test
     nest g -c @scrypt-swiss/nest-templates db
     nest g -c @scrypt-swiss/nest-templates res user
-    npm install
+    npm ci --ignore-scripts
     npm run build
     docker-compose up -d db
     npm run migration:initial

--- a/src/lib/application/files/common/Dockerfile
+++ b/src/lib/application/files/common/Dockerfile
@@ -1,13 +1,13 @@
 FROM mwaeckerlin/nodejs-build AS build
 RUN mkdir temp
-COPY --chown=${BUILD_USER} package.json package-lock.json ./
-RUN npm install
+COPY --chown=${BUILD_USER} package.json package-lock.json .npmrc ./
+RUN npm ci --ignore-scripts
 COPY --chown=${BUILD_USER} . .
 RUN npm run build
 
 FROM mwaeckerlin/nodejs-build AS node-modules
-COPY --chown=${BUILD_USER} package.json package-lock.json ./
-RUN npm install
+COPY --chown=${BUILD_USER} package.json package-lock.json .npmrc ./
+RUN npm ci --ignore-scripts --omit=dev
 
 FROM mwaeckerlin/nodejs as production
 EXPOSE 4000

--- a/src/lib/sub-app/files/common/Dockerfile
+++ b/src/lib/sub-app/files/common/Dockerfile
@@ -2,11 +2,11 @@ ARG DOCKER_REPOSITORY
 ARG DOCKER_TAG
 FROM ${DOCKER_REPOSITORY}/base:${DOCKER_TAG:-latest} AS build
 COPY --chown=${BUILD_USER} . <%= path %>/<%= name %>
-RUN npm install
+RUN npm ci --ignore-scripts
 RUN npx nx run <%= name %>:build
 ENV NODE_ENV 'production'
 RUN find -name node_modules -prune -exec rm -rf {} \;
-RUN npm install
+RUN npm ci --ignore-scripts --omit=dev
 WORKDIR /app/<%= path %>/<%= name %>
 RUN nexe --build --python=$(which python3) -r "temp" -r "dist/migrations" -o app dist/src/main.js
 

--- a/src/lib/sub-app/files/common/Dockerfile
+++ b/src/lib/sub-app/files/common/Dockerfile
@@ -10,6 +10,6 @@ RUN npm ci --ignore-scripts --omit=dev
 WORKDIR /app/<%= path %>/<%= name %>
 RUN nexe --build --python=$(which python3) -r "temp" -r "dist/migrations" -o app dist/src/main.js
 
-FROM mwaeckerlin/nexe as production
+FROM ${DOCKER_REPOSITORY}/platform/base/nodejs-20-runtime-nexe:2.0.0 AS production
 EXPOSE <%= port %>
 COPY --from=build /app/<%= path %>/<%= name %>/app /app/app


### PR DESCRIPTION
Harden Docker build templates against supply chain attacks by using npm ci --ignore-scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker builds now use deterministic dependency installs and skip lifecycle scripts for safer builds.
  * Production images omit dev dependencies for smaller, leaner deployments.
  * Multi-stage build artifact handling improved and production base image updated for more reliable image composition.
* **Documentation**
  * README examples updated to use the deterministic install command for reproducible builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->