### PR TITLE
fix(security): add prototype pollution guards in resolveRefs

### DIFF
--- a/src/lib/openapi/openapi.factory.ts
+++ b/src/lib/openapi/openapi.factory.ts
@@ -105,13 +105,17 @@ export function main(options: any): Rule {
 function resolveRefs(json, original = null) {
     original ??= json
     for (let k in json) {
+        if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue  // Prevent prototype pollution
         if (k === '$ref' && json[k].match(/^#\//)) {
             let tmp = original
             let arr = json[k].split('/')
             json.dto = arr[arr.length - 1]
             while (arr.shift(), arr.length) tmp = tmp[arr[0]]
             delete json[k]
-            for (let k2 in tmp) json[k2] = tmp[k2]
+            for (let k2 in tmp) {
+                if (k2 === '__proto__' || k2 === 'constructor' || k2 === 'prototype') continue  // Prevent prototype pollution
+                json[k2] = tmp[k2]
+            }
         } else if (typeof json[k] === 'object') {
             json[k] = resolveRefs(json[k], original)
         }


### PR DESCRIPTION
This PR addresses a prototype pollution vulnerability detected by the Aikido security scanner in the `resolveRefs` function. While I don't consider this critical since the code only runs at build-time and processes trusted OpenAPI specifications from known sources, I'm implementing this fix as a defense-in-depth security measure. The changes add guards to filter out dangerous property names (`__proto__`, `constructor`, and `prototype`) in for...in loops, protecting against potential supply chain attacks involving compromised third-party OpenAPI specs.

Related: https://github.com/Scrypt-Swiss/openapi-client/pull/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security protections to prevent property injection vulnerabilities that could compromise system stability and data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->